### PR TITLE
Create config directory for prometheus

### DIFF
--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -26,6 +26,13 @@
     owner: prometheus
     group: prometheus
 
+- name: create config directory
+  file:
+    path: /etc/prometheus
+    state: directory
+    owner: prometheus
+    group: prometheus
+
 - name: copy systemd file
   template:
     src: prometheus.service.j2


### PR DESCRIPTION
I ran into the following error when executing the playbook and added a task to create `/etc/prometheus` directory.

```
$ ansible-playbook -i inventories/hosts jetson.yml
PLAY [jetson] *********************************************************************************************************************************************************************************************************************************
...
TASK [copy prometheus.yml] ********************************************************************************************************************************************************************************************************************
fatal: [192.168.3.45]: FAILED! => {"changed": false, "checksum": "de698646cbc44fb5954c211c501365b456052d97", "msg": "Destination directory /etc/prometheus does not exist"}```